### PR TITLE
getting-started: remove ilab version from venv name

### DIFF
--- a/docs/getting-started/linux_nvidia.md
+++ b/docs/getting-started/linux_nvidia.md
@@ -11,9 +11,8 @@ logo: images/ilab_dog.png
 !!! note
     These steps will pull down a premade `qna.yaml` so you can do a local build. Skip the `wget`, `mv`, and `ilab taxonomy diff` if you don't want to do this.
 
-```bash
-python3.11 -m venv venv-instructlab-0.18-3.11
-source venv-instructlab-0.18-3.11/bin/activate
+python3.11 -m venv --upgrade-deps venv
+source venv/bin/activate
 pip cache remove llama_cpp_python
 pip install 'instructlab[cuda]' \
    -C cmake.args="-DLLAMA_CUDA=on" \

--- a/docs/getting-started/mac_metal.md
+++ b/docs/getting-started/mac_metal.md
@@ -11,8 +11,8 @@ logo: images/ilab_dog.png
     These steps will pull down a premade `qna.yaml` so you can do a local build. Skip the `wget`, `mv`, and `ilab taxonomy diff` if you don't want to do this.
 
 ```bash
-python3.11 -m venv venv-instructlab-0.18-3.11
-source venv-instructlab-0.18-3.11/bin/activate
+python3.11 -m venv --upgrade-deps venv
+source venv/bin/activate
 pip install 'instructlab[mps]'
 which ilab
 ilab config init


### PR DESCRIPTION
Removes ilab version from the virtual environment name.
This will always be out-of-date, or it will have to be updated with each new version.
Using just `venv` makes this aligned with the rest of the docs and with instructions in README.md of the instructlab