### PR TITLE
update website to include references to discord

### DIFF
--- a/docs/community/CODE_OF_CONDUCT_COMMITTEE.md
+++ b/docs/community/CODE_OF_CONDUCT_COMMITTEE.md
@@ -4,6 +4,8 @@ We take reports of violations to our project [Code of Conduct](https://github.co
 
 To report a Code of Conduct violation to our Code of Conduct Committee, you may reach out to us by email at [coc@instructlab.ai](mailto:coc@instructlab.ai). The email will be read and acted upon by our Code of Conduct Committee members.
 
+If you experience a Code of Conduct violation in our InstructLab Discord workspace, please follow the [instructions in our moderation guide](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_MODERATION_GUIDE.md#reporting-abuse) to get immediate help in Discord.
+
 If you experience a Code of Conduct violation in our InstructLab Slack workspace, please follow the [instructions in our moderation guide](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_MODERATION_GUIDE.md#reporting-abuse) to get immediate help in Slack.
 
 As part of our follow up on your report, we would like to contact you for further discussion. If you would prefer not to engage beyond reporting the matter to the committee, please let us know that as part of your submission. We will respect your request.

--- a/docs/community/FAQ.md
+++ b/docs/community/FAQ.md
@@ -94,7 +94,7 @@ The goal on the InstructLab project is to emocratize contributions to AI and LLM
 
 ### How can I contribute?
 
-You can begin your contribution journey by reading over the [Contributing](https://github.com/instruct-lab/community/blob/main/CONTRIBUTING.md) guide and joining the [Community Slack Channel](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md).
+You can begin your contribution journey by reading over the [Contributing](https://github.com/instruct-lab/community/blob/main/CONTRIBUTING.md) guide and joining the [Community Discord Server](https://instructlab.ai/discord) or the [Community Slack Channel](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md).
 
 When you're ready to start contributing, you can follow the [Getting Started](https://github.com/instruct-lab/community/blob/main/README.md#getting-started-with-the-instructlab-project-workstreams) guide. This guide shows you how to
 
@@ -230,7 +230,7 @@ The latest version of InstructLab can be downloaded using the `ilab download` CL
 
 ### I have a question about the project. Where should I go?
 
-Currently, the best method for communicating with peers and project maintainers is in the Community Slack Channel. Visit our [InstructLab Slack Workspace Guide](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md) for information on how to join.
+Currently, the best method for communicating with peers and project maintainers is in the Community Discord/Slack servers. Visit our [InstructLab Slack Workspace Guide](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md), [InstructLab Slack Workspace Guide](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_GUIDE.md) for information on how to join.
 
 See our [community collaboration page](https://github.com/instructlab/community/blob/main/Collaboration.md), including information on our mailing list, meetings, and other ways of interacting with the community.
 
@@ -284,13 +284,18 @@ To run and train InstructLab locally, you must meet the following requirements:
 
 ## Additional Resources
 
-Additional resources, including the Code of Conduct, Code of Conduct Committee members, how to contribute, how to join the Slack channel, and more, can be found in the following repositories:
+Additional resources, including the Code of Conduct, Code of Conduct Committee members, how to contribute, how to join the Discord or Slack server, and more, can be found in the following repositories:
 
 [InstructLab Taxonomy Repository](https://github.com/instructlab/taxonomy)
 
 [InstructLab CLI Repository](https://github.com/instructlab/instructlab)
 
 [InstructLab Community Repository](https://github.com/instructlab/community)
+
+Discord and communication
+
+- [Joining the Discord Server](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md)
+- [Discord Moderation](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_MODERATION_GUIDE.md)
 
 Slack and communication
 

--- a/docs/community/GOVERNANCE.md
+++ b/docs/community/GOVERNANCE.md
@@ -15,7 +15,7 @@ The InstructLab Project has a two-level governance structure with an Oversight C
 
 Except where otherwise noted, decisions should always start at the most local level of project governance. For example, decisions that affect only one project, such as the taxonomy repository and not the `ilab` CLI tool, can happen within the taxonomy project. While communication between the different project teams is important as they are all interconnected, minor decisions do not need organization-wide consensus and can be moved forward at the project level.
 
-Changes in maintainership and other governance are currently announced on the InstructLab community Slack channel. Directions to join the Slack channel can be found [here](https://github.com/instructlab/community/blob/main/InstructLabSlackGuide.md). Changes are also announced to the [announce mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
+Changes in maintainership and other governance are currently announced on the InstructLab community Discord and Slack servers. Directions to join the Discord server can be found [here](https://github.com/instructlab/community/blob/main/InstructLab_DISCORD_GUIDE.md), and instructions for the Slack server can be found [here](https://github.com/instructlab/community/blob/main/InstructLab_SLACK_GUIDE.md). Changes are also announced to the [announce mailing list](https://github.com/instructlab/community/blob/main/Collaboration.md#email-lists).
 
 ## Project Maintainers overview
 

--- a/docs/community/InstructLab_DISCORD_GUIDE.md
+++ b/docs/community/InstructLab_DISCORD_GUIDE.md
@@ -1,0 +1,52 @@
+# InstructLab Discord Server Guide
+
+The purpose of this document is to inform members about how to join the
+[InstructLab Discord Server](https://instructlab.ai/discord) and outline the channels available. We look forward
+to meeting everyone and welcoming you to Discord!
+
+## Overview
+
+The InstructLab Discord server can be accessed via this [invitation link](https://instructlab.ai/discord).
+
+Upon joining, you will automatically be assigned the `@Labs` role and gain access to the `#announcements` channel, as
+well as a number of the other default channels. You are welcome and encouraged to join other channels that may exist.
+
+All discussions in the InstructLab Discord server are governed by our
+[project code of conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md).
+
+## Opt-in Channels
+
+To ensure that users are not overwhelmed by notifications, we have a few automated channels as opt-in only. In order to
+join them, visit the `#welcome-and-rules` channels and react with the emoji corresponding to the channel you wish to
+join.
+
+Currently, these channels are:
+
+- `#receive-e2e-logs`: Pushes updates about E2E runs that take place in our GitHub CI, allowing users to watch for failures.
+
+## Moderation and Reporting Abuse
+
+We are an open, welcoming, and inclusive community and expect our members to be kind and respectful in all discourse.
+
+We take reports of harassment very seriously and will address any reports of inappropriate behavior as quickly as possible.
+
+To learn how to report abuse – and to whom you will be reporting – please see our [InstructLab Discord Moderation Guide](https://github.com/instructlab/community/blob/main/InstructLabDiscordModerationGuide.md).
+
+## Having Trouble Joining?
+
+If you are having trouble joining the InstructLab Discord server, please file an issue in the
+[community repo](https://github.com/instructlab/community/issues) so we can help you.
+
+TODO: Update with email address to get help once these are set up.
+
+## Private Channels
+
+InstructLab is an open-source project and we value defaulting to open in all of our community communications.
+However, there are some cases where discussions must happen in private. For the sake of transparency, we are documenting
+these private channels and their purposes.
+
+- `#code-of-conduct-committee` – Space for the InstructLab
+[Code of Conduct Committee](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT_COMMITTEE.md) to discuss
+any reports of harassment or other violations of the project Code of Conduct and how to respond to them.
+- `#admin` – Space for the InstructLab Server Administrators to confer privately only when
+necessary. We default to open channels and hold each other accountable to do so.

--- a/docs/community/InstructLab_DISCORD_MODERATION_GUIDE.md
+++ b/docs/community/InstructLab_DISCORD_MODERATION_GUIDE.md
@@ -1,0 +1,70 @@
+# InstructLab Discord Moderation Guide
+
+The purpose of this document is to describe how users of the
+[InstructLab Discord server](https://instructlab.ai/discord) can report abuse within the Discord server and to provide
+server administrators with an easy-to-use guide for channel moderation.
+
+## Reporting Abuse
+
+Should any community members using the InstructLab Discord server feel that they have experienced behavior that violates
+our [project Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md), they are welcome
+and encouraged to contact the members of the
+[Code of Conduct Committee](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT_COMMITTEE.md) for help.
+Mentioning `@dog-watch` will notify all members of the moderation team so that they can assist you.
+
+In the event that you do not receive help within a timely fashion – and we will do our very best to respond right away –
+you can ask for help from the server admins by either joining the `#ask-an-admin` channel or mentioning `@admins`. If
+you feel that it is a personal matter, you can also ping one of the people with the role of `#dog-watch` directly.
+
+## Moderation Guide
+
+Moderation activities can only be performed by users who are designated as server administrators (i.e. `@dog-watch`/
+`@lead-retriever`).
+
+## Server Administrators
+
+At the time of writing this, anyone with either the `@dog-watch` or `@lead-retriever` role is considered to be a
+moderator or administrator respectively.
+
+\+ Members of the
+[Code of Conduct Committee](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT_COMMITTEE.md)
+
+## How We Moderate
+
+### Deleting Inappropriate Comments
+
+Upon a report of abuse to the [Code of Conduct Committee](https://github.com/instructlab/community/blob/main/COCC.md)
+or, alternatively, if needed to the server administrators due to a coverage gap, the appropriate parties will assess
+the situation.
+
+The first step will be to remind individuals to abide by the [project Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md).
+
+Inappropriate or offensive messages will be deleted. To delete a message, simply click on the three vertical dots that
+appear when you hover over a message, or on mobile simply tap and hold on a message, and then click the **Delete**
+button:
+
+![Delete Message](https://raw.githubusercontent.com/instructlab/community/main/public/images/discord_delete_message.png)
+
+Deleting a message shall be done at the sole discretion of the Code of Conduct Committee and/or server administrators.
+
+### Removing Server Members
+
+Admins should consider first removing the offending person's messages from the channel in which the unacceptable
+behavior occurred and having a conversation with them via Direct Message (DM) to remind them of their responsibilities
+to abide by the [project Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md) as
+part of their participation in the InstructLab community.
+
+If a user is a repeat offender, after being warned, their account can be
+[kicked/banned](https://whop.com/blog/how-to-kick-someone-from-a-discord-server/) by an admin, depending on the
+situation.
+
+For more details on moderating a Discord server, please refer to the following guides:
+
+- [How to kick someone from a Discord server](https://whop.com/blog/how-to-kick-someone-from-a-discord-server/)
+- [Auto Moderation in Discord](https://discord.com/safety/auto-moderation-in-discord)
+
+#### Banning a Member's Account
+
+If you feel that a community member is violating the
+[InstructLab Code of Conduct](https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md), please reach out
+to the server moderators or the Code of Conduct Committee to receive further assistance.

--- a/docs/user-interface/env_oauth_config.md
+++ b/docs/user-interface/env_oauth_config.md
@@ -48,4 +48,4 @@ Once the app is created, there will be an option to create a secret. Press the C
 Update the .env files with the new ID and secret ID generated, `OAUTH_GITHUB_ID` = Client ID, `OAUTH_GITHUB_SECRET` = Client Secret
 
 !!! note 
-    If you prefer to not set up the OAuth, we recommend for you to reach out to the UI Maintainers in our `#ui` [slack channel](https://join.slack.com/t/instruct-lab/shared_invite/zt-2kieyqiz9-zhXSxGnXk6uL_f3hVbD53g) , where they will provide details for setting up an OAuth app for the instructlab-public org.
+    If you prefer to not set up the OAuth, we recommend for you to reach out to the UI Maintainers in our `#ui` [discord server](https://instructlab.ai/discord) or [slack channel](https://join.slack.com/t/instruct-lab/shared_invite/zt-2kieyqiz9-zhXSxGnXk6uL_f3hVbD53g) , where they will provide details for setting up an OAuth app for the instructlab-public org.

--- a/docs/user-interface/ui_overview.md
+++ b/docs/user-interface/ui_overview.md
@@ -20,7 +20,7 @@ There are 2 ways to access the UI:
     To log into the UI and submit Knowledge and Skills contributions, you must be a member of the [instructlab-public](https://github.com/instructlab-public) github repository.
 
 !!! note
-    If you aren't a member of the repository, but still wish to experiment with the UI, we recommend you to reach out to the UI Maintainers in our `#ui` [slack channel](https://join.slack.com/t/instruct-lab/shared_invite/zt-2kieyqiz9-zhXSxGnXk6uL_f3hVbD53g) for an invitation.
+    If you aren't a member of the repository, but still wish to experiment with the UI, we recommend you to reach out to the UI Maintainers in our `#ui` [Discord server](https://instructlab.ai/discord) or [slack channel](https://join.slack.com/t/instruct-lab/shared_invite/zt-2kieyqiz9-zhXSxGnXk6uL_f3hVbD53g) for an invitation.
     
     If you wish to not join but still wish to experiment, download it locally.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ nav:
       - Code of Conduct Committee: community/CODE_OF_CONDUCT_COMMITTEE.md
       - FAQ: community/FAQ.md
       - Governance Policy: community/GOVERNANCE.md
+      - Discord Guide: community/InstructLab_DISCORD_GUIDE.md
+      - Discord Moderation Guide: community/InstructLab_DISCORD_MODERATION_GUIDE.md
       - Slack Guide: community/InstructLab_SLACK_GUIDE.md
       - Slack Moderation Guide: community/InstructLab_SLACK_MODERATION_GUIDE.md
   - Taxonomy:


### PR DESCRIPTION
Now that we have a community Discord server at https://instructlab.ai/discord, this PR updates the existing references to also point to the Discord server in addition to the Slack server.

Additionally, there were a number of dead links which were pointing to the incorrect path for the community Slack guide, which have also been updated to point to the correct guide.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
