### PR TITLE
improve the rendering of the label links

### DIFF
--- a/docs/taxonomy/knowledge/contribution_details.md
+++ b/docs/taxonomy/knowledge/contribution_details.md
@@ -68,8 +68,8 @@ the place that it is in.
 | --- | --- | --- | --- |
 | | Contributor | Submit PR | - |
 | | Contributor | Fix failed PR checks | - |
-| https://github.com/instructlab/taxonomy/labels/triage-needed | Triager | Review PR, ask for changes | Days |
-| https://github.com/instructlab/taxonomy/labels/triage-requested-changes | Contributor | Make requested changes | Days |
-| https://github.com/instructlab/taxonomy/labels/precheck-generate-ready | Triager | Run prechecks and generate  | Days |
-| https://github.com/instructlab/taxonomy/labels/community-build-ready | Backend | Model gets retrained | Weeks |
+| [triage-needed](https://github.com/instructlab/taxonomy/labels/triage-needed) | Triager | Review PR, ask for changes | Days |
+| [triage-requested-changes](https://github.com/instructlab/taxonomy/labels/triage-requested-changes) | Contributor | Make requested changes | Days |
+| [precheck-generate-ready](https://github.com/instructlab/taxonomy/labels/precheck-generate-ready) | Triager | Run prechecks and generate  | Days |
+| [community-build-ready](https://github.com/instructlab/taxonomy/labels/community-build-ready) | Backend | Model gets retrained | Weeks |
 | | Triager | Check the numbers and PR merged or closed | - |


### PR DESCRIPTION
improve the rendering of the label links, in the docs to have href, when you open on smaller screens.

**Before the fix:**
![Screenshot 2025-01-23 at 10 44 18](https://github.com/user-attachments/assets/befcefa8-9a5a-4e50-a02c-ca39abfc21fd)


**After the fix:**
![Screenshot 2025-01-23 at 10 44 06](https://github.com/user-attachments/assets/8f7d20c6-07ba-4d32-b236-7bca95bdf539)
