### PR TITLE
Add "Next Steps" section to installation guides for Linux and Mac

### DIFF
--- a/docs/getting-started/linux_amd.md
+++ b/docs/getting-started/linux_amd.md
@@ -150,3 +150,9 @@ you can save the completion script and source it from `~/.bashrc`:
 ```sh
 _ILAB_COMPLETE=fish_source ilab > ~/.config/fish/completions/ilab.fish
 ```
+
+## Next Steps
+
+Now that you have InstructLab installed, the next step is to initialize your environment.
+
+[Initialize InstructLab](../getting-started/initilize_ilab.md){: .md-button .md-button--primary }

--- a/docs/getting-started/linux_nvidia.md
+++ b/docs/getting-started/linux_nvidia.md
@@ -143,3 +143,9 @@ you can save the completion script and source it from `~/.bashrc`:
 ```sh
 _ILAB_COMPLETE=fish_source ilab > ~/.config/fish/completions/ilab.fish
 ```
+
+## Next Steps
+
+Now that you have InstructLab installed, the next step is to initialize your environment.
+
+[Initialize InstructLab](../getting-started/initilize_ilab.md){: .md-button .md-button--primary }

--- a/docs/getting-started/mac_metal.md
+++ b/docs/getting-started/mac_metal.md
@@ -142,3 +142,9 @@ you can save the completion script and source it from `~/.bashrc`:
 ```sh
 _ILAB_COMPLETE=fish_source ilab > ~/.config/fish/completions/ilab.fish
 ```
+
+## Next Steps
+
+Now that you have InstructLab installed, the next step is to initialize your environment.
+
+[Initialize InstructLab](../getting-started/initilize_ilab.md){: .md-button .md-button--primary }


### PR DESCRIPTION
Hey Folks,  

While going thru the docs and setting up `ilab` it wasn't immediately clear to me where to go after finishing the installation.  I added a next steps section so that it would be clear where users should go next. 

<img width="1118" alt="Screenshot 2025-02-06 at 4 19 24 PM" src="https://github.com/user-attachments/assets/0fe91a8d-6616-4596-b8e2-46232b17f328" />
